### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # spotify-mcp MCP server
+[![smithery badge](https://smithery.ai/badge/spotify-mcp)](https://smithery.ai/server/spotify-mcp)
 
 MCP project to connect Claude with Spotify. Built on top of [spotipy-dev's API](https://github.com/spotipy-dev/spotipy/tree/2.24.0).
 
@@ -23,6 +24,16 @@ Create an app with redirect_uri as http://localhost:8888. (You can choose any po
 I set "APIs used" to "Web Playback SDK".
 
 ### Run this project locally
+
+#### Installing via Smithery
+
+To install Spotify Connector for Claude Desktop automatically via [Smithery](https://smithery.ai/server/spotify-mcp):
+
+```bash
+npx -y @smithery/cli install spotify-mcp --client claude
+```
+
+#### Manual Installation
 This project is not yet set up for ephemeral environments (e.g. `uvx` usage). 
 Run this project locally by cloning this repo
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Spotify Connector for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/spotify-mcp

Let me know if any tweaks have to be made!