### PR TITLE
Add support for manipulating playlists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.cache
+**/__pycache__

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Any
 
 import spotipy
 from dotenv import load_dotenv
@@ -25,6 +25,11 @@ SCOPES = ["user-read-currently-playing", "user-read-playback-state", "user-read-
 
 
 class Client:
+    sp: spotipy.Spotify
+    auth_manager: SpotifyOAuth
+    cache_handler: CacheFileHandler
+    logger: logging.Logger
+
     def __init__(self, logger: logging.Logger):
         """Initialize Spotify client with necessary permissions"""
         self.logger = logger
@@ -32,19 +37,20 @@ class Client:
         scope = "user-library-read,user-read-playback-state,user-modify-playback-state,user-read-currently-playing"
 
         try:
-            self.sp = spotipy.Spotify(auth_manager=SpotifyOAuth(
+            auth_manager = SpotifyOAuth(
                 scope=scope,
                 client_id=CLIENT_ID,
                 client_secret=CLIENT_SECRET,
-                redirect_uri=REDIRECT_URI))
+                redirect_uri=REDIRECT_URI)
 
-            self.auth_manager: SpotifyOAuth = self.sp.auth_manager
-            self.cache_handler: CacheFileHandler = self.auth_manager.cache_handler
+            self.sp = spotipy.Spotify(auth_manager=auth_manager)
+            self.auth_manager = auth_manager
+            self.cache_handler = auth_manager.cache_handler
         except Exception as e:
             self.logger.error(f"Failed to initialize Spotify client: {str(e)}", exc_info=True)
             raise
 
-    def search(self, query: str, qtype: str = 'track', limit=10):
+    def search(self, query: str, qtype: str = 'track', limit: int = 10) -> Dict[str, List[Dict[str, Any]]]:
         """
         Searches based of query term.
         - query: query term
@@ -53,15 +59,15 @@ class Client:
         - limit: max # items to return
         """
         results = self.sp.search(q=query, limit=limit, type=qtype)
-        return utils.parse_search_results(results, qtype)
+        search_results = utils.parse_search_results(results, qtype)
+        return search_results if search_results else {}
 
-
-    def recommendations(self, artists: Optional[List] = None, tracks: Optional[List] = None, limit=20):
+    def recommendations(self, artists: Optional[List[str]] = None, tracks: Optional[List[str]] = None,
+                       limit: int = 20) -> Dict[str, Any]:
         recs = self.sp.recommendations(seed_artists=artists, seed_tracks=tracks, limit=limit)
-        return recs
+        return recs if recs else {}
 
-
-    def get_info(self, item_id: str, qtype: str = 'track') -> dict:
+    def get_info(self, item_id: str, qtype: str = 'track') -> Dict[str, Any]:
         """
         Returns more info about item.
         - item_id: id.
@@ -69,36 +75,38 @@ class Client:
         """
         match qtype:
             case 'track':
-                return utils.parse_track(self.sp.track(item_id), detailed=True)
+                track_info = utils.parse_track(self.sp.track(item_id), detailed=True)
+                return track_info if track_info else {}
             case 'album':
                 album_info = utils.parse_album(self.sp.album(item_id), detailed=True)
-                return album_info
-
+                return album_info if album_info else {}
             case 'artist':
                 artist_info = utils.parse_artist(self.sp.artist(item_id), detailed=True)
+                if not artist_info:
+                    return {}
                 albums = self.sp.artist_albums(item_id)
-                top_tracks = self.sp.artist_top_tracks(item_id)['tracks']
+                top_tracks_response = self.sp.artist_top_tracks(item_id)
+                if not top_tracks_response:
+                    return artist_info
+
                 albums_and_tracks = {
                     'albums': albums,
-                    'tracks': {'items': top_tracks}
+                    'tracks': {'items': top_tracks_response.get('tracks', [])}
                 }
                 parsed_info = utils.parse_search_results(albums_and_tracks, qtype="album,track")
-                artist_info['top_tracks'] = parsed_info['tracks']
-                artist_info['albums'] = parsed_info['albums']
-
+                artist_info['top_tracks'] = parsed_info.get('tracks', [])
+                artist_info['albums'] = parsed_info.get('albums', [])
                 return artist_info
             case 'playlist':
                 playlist = self.sp.playlist(item_id)
                 playlist_info = utils.parse_playlist(playlist, detailed=True)
+                return playlist_info if playlist_info else {}
 
-                return playlist_info
+        raise ValueError(f"unknown qtype {qtype}")
 
-        raise ValueError(f"uknown qtype {qtype}")
-
-    def get_current_track(self) -> Optional[Dict]:
+    def get_current_track(self) -> Optional[Dict[str, Any]]:
         """Get information about the currently playing track"""
         try:
-            # current_playback vs current_user_playing_track?
             current = self.sp.current_user_playing_track()
             if not current:
                 self.logger.info("No playback session found")
@@ -107,7 +115,10 @@ class Client:
                 self.logger.info("Current playback is not a track")
                 return None
 
-            track_info = utils.parse_track(current['item'])
+            track_info = utils.parse_track(current.get('item'))
+            if not track_info:
+                return None
+
             if 'is_playing' in current:
                 track_info['is_playing'] = current['is_playing']
 
@@ -119,7 +130,8 @@ class Client:
             raise
 
     @utils.validate
-    def start_playback(self, track_id=None, device=None):
+    def start_playback(self, track_id: Optional[str] = None,
+                      device: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
         """
         Starts track playback. If track_id is omitted, resumes current playback.
         - track_id: ID of track to play, or None.
@@ -128,7 +140,7 @@ class Client:
             if not track_id:
                 if self.is_track_playing():
                     self.logger.info("No track_id provided and playback already active.")
-                    return
+                    return None
                 if not self.get_current_track():
                     raise ValueError("No track_id provided and no current playback to resume.")
 
@@ -143,14 +155,14 @@ class Client:
             raise
 
     @utils.validate
-    def pause_playback(self, device=None):
+    def pause_playback(self, device: Optional[Dict[str, Any]] = None) -> None:
         """Pauses playback."""
         playback = self.sp.current_playback()
         if playback and playback.get('is_playing'):
             self.sp.pause_playback(device.get('id') if device else None)
 
     @utils.validate
-    def add_to_queue(self, track_id: str, device=None):
+    def add_to_queue(self, track_id: str, device: Optional[Dict[str, Any]] = None) -> None:
         """
         Adds track to queue.
         - track_id: ID of track to play.
@@ -158,48 +170,63 @@ class Client:
         self.sp.add_to_queue(track_id, device.get('id') if device else None)
 
     @utils.validate
-    def get_queue(self, device=None):
+    def get_queue(self, device: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Returns the current queue of tracks."""
         queue_info = self.sp.queue()
-        self.logger.info(f"currently playing keys {queue_info['currently_playing'].keys()}")
+        if not queue_info:
+            return {'currently_playing': None, 'queue': []}
+
+        self.logger.info(f"currently playing keys {queue_info.get('currently_playing', {}).keys()}")
 
         queue_info['currently_playing'] = self.get_current_track()
-
-        queue_info['queue'] = [utils.parse_track(track) for track in queue_info.pop('queue')]
+        queue = queue_info.pop('queue', [])
+        queue_info['queue'] = [track_info for track in queue
+                             if (track_info := utils.parse_track(track)) is not None]
 
         return queue_info
 
-    def get_liked_songs(self):
-        # todo
+    def get_liked_songs(self) -> List[Dict[str, Any]]:
         results = self.sp.current_user_saved_tracks()
-        for idx, item in enumerate(results['items']):
-            track = item['track']
-            print(idx, track['artists'][0]['name'], " – ", track['name'])
+        if not results or 'items' not in results:
+            return []
+
+        tracks = []
+        for item in results['items']:
+            if track := item.get('track'):
+                if track_info := utils.parse_track(track):
+                    tracks.append(track_info)
+        return tracks
 
     def is_track_playing(self) -> bool:
         """Returns if a track is actively playing."""
         curr_track = self.get_current_track()
         if not curr_track:
             return False
-        if curr_track.get('is_playing'):
-            return True
-        return False
+        return bool(curr_track.get('is_playing'))
 
-    def get_devices(self) -> dict:
-        return self.sp.devices()['devices']
+    def get_devices(self) -> List[Dict[str, Any]]:
+        """Get list of available devices"""
+        devices = self.sp.devices()
+        return devices.get('devices', []) if devices else []
 
-    def is_active_device(self):
-        return any([device.get('is_active') for device in self.get_devices()])
+    def is_active_device(self) -> bool:
+        """Check if there is an active device"""
+        return any(device.get('is_active', False) for device in self.get_devices())
 
-    def _get_candidate_device(self):
+    def _get_candidate_device(self) -> Optional[Dict[str, Any]]:
+        """Get an active device or the first available device"""
         devices = self.get_devices()
+        if not devices:
+            return None
+
         for device in devices:
             if device.get('is_active'):
                 return device
-        self.logger.info(f"No active device, assigning {devices[0]['name']}.")
+        self.logger.info(f"No active device, assigning {devices[0].get('name', 'Unknown')}.")
         return devices[0]
 
     def auth_ok(self) -> bool:
+        """Check if authentication is valid"""
         try:
             result = self.auth_manager.is_token_expired(self.cache_handler.get_cached_token())
             self.logger.info(f"Auth check result: {'valid' if not result else 'expired'}")
@@ -208,19 +235,160 @@ class Client:
             self.logger.error(f"Error checking auth status: {str(e)}", exc_info=True)
             raise
 
-    def auth_refresh(self):
+    def auth_refresh(self) -> None:
+        """Refresh authentication token"""
         self.auth_manager.validate_token(self.cache_handler.get_cached_token())
 
-    def skip_track(self, n=1):
-        # todo: Better error handling
+    def skip_track(self, n: int = 1) -> None:
+        """Skip n tracks"""
         for _ in range(n):
             self.sp.next_track()
 
-    def previous_track(self):
+    def previous_track(self) -> None:
+        """Go to previous track"""
         self.sp.previous_track()
 
-    def seek_to_position(self, position_ms):
+    def seek_to_position(self, position_ms: int) -> None:
+        """Seek to position in current track"""
         self.sp.seek_track(position_ms=position_ms)
 
-    def set_volume(self, volume_percent):
+    def set_volume(self, volume_percent: int) -> None:
+        """Set playback volume"""
         self.sp.volume(volume_percent)
+
+    # Playlist Methods
+    def get_playlist(self, playlist_id: str) -> Dict[str, Any]:
+        """Get a playlist's details"""
+        try:
+            playlist = self.sp.playlist(playlist_id)
+            playlist_info = utils.parse_playlist(playlist, detailed=True)
+            return playlist_info if playlist_info else {}
+        except Exception as e:
+            self.logger.error(f"Error getting playlist: {str(e)}", exc_info=True)
+            raise
+
+    def update_playlist_details(self, playlist_id: str, name: Optional[str] = None,
+                              description: Optional[str] = None, public: Optional[bool] = None) -> None:
+        """Update a playlist's details"""
+        try:
+            self.sp.playlist_change_details(
+                playlist_id,
+                name=name,
+                description=description,
+                public=public
+            )
+        except Exception as e:
+            self.logger.error(f"Error updating playlist: {str(e)}", exc_info=True)
+            raise
+
+    def update_playlist_items(self, playlist_id: str, uris: List[str],
+                            range_start: Optional[int] = None,
+                            insert_before: Optional[int] = None,
+                            range_length: Optional[int] = None,
+                            snapshot_id: Optional[str] = None) -> Dict[str, str]:
+        """Update a playlist's items"""
+        try:
+            result = self.sp.playlist_replace_items(playlist_id, uris)
+            if range_start is not None and insert_before is not None:
+                # If range parameters provided, reorder items
+                self.sp.playlist_reorder_items(
+                    playlist_id,
+                    range_start=range_start,
+                    insert_before=insert_before,
+                    range_length=range_length or 1,  # Default to 1 if None
+                    snapshot_id=snapshot_id
+                )
+            return result if result else {"snapshot_id": ""}
+        except Exception as e:
+            self.logger.error(f"Error updating playlist items: {str(e)}", exc_info=True)
+            raise
+
+    def add_playlist_items(self, playlist_id: str, uris: List[str],
+                         position: Optional[int] = None) -> Dict[str, str]:
+        """Add items to a playlist"""
+        try:
+            result = self.sp.playlist_add_items(playlist_id, uris, position=position)
+            return result if result else {"snapshot_id": ""}
+        except Exception as e:
+            self.logger.error(f"Error adding items to playlist: {str(e)}", exc_info=True)
+            raise
+
+    def remove_playlist_items(self, playlist_id: str, uris: List[str],
+                            snapshot_id: Optional[str] = None) -> Dict[str, str]:
+        """Remove items from a playlist"""
+        try:
+            result = self.sp.playlist_remove_all_occurrences_of_items(
+                playlist_id,
+                uris,
+                snapshot_id=snapshot_id
+            )
+            return result if result else {"snapshot_id": ""}
+        except Exception as e:
+            self.logger.error(f"Error removing items from playlist: {str(e)}", exc_info=True)
+            raise
+
+    def get_user_playlists(self, user_id: Optional[str] = None,
+                          limit: int = 20, offset: int = 0) -> Dict[str, Any]:
+        """Get a user's playlists"""
+        try:
+            if user_id:
+                playlists = self.sp.user_playlists(user_id, limit=limit, offset=offset)
+            else:
+                playlists = self.sp.current_user_playlists(limit=limit, offset=offset)
+
+            if not playlists:
+                return {
+                    'items': [],
+                    'total': 0,
+                    'limit': limit,
+                    'offset': offset,
+                    'next': None,
+                    'previous': None
+                }
+
+            # Parse the playlists
+            return {
+                'items': [playlist_info for playlist in playlists.get('items', [])
+                         if (playlist_info := utils.parse_playlist(playlist)) is not None],
+                'total': playlists.get('total', 0),
+                'limit': playlists.get('limit', limit),
+                'offset': playlists.get('offset', offset),
+                'next': playlists.get('next'),
+                'previous': playlists.get('previous')
+            }
+        except Exception as e:
+            self.logger.error(f"Error getting user playlists: {str(e)}", exc_info=True)
+            raise
+
+    def create_playlist(self, user_id: str, name: str, description: str = "",
+                       public: bool = False) -> Dict[str, Any]:
+        """Create a new playlist"""
+        try:
+            playlist = self.sp.user_playlist_create(
+                user_id,
+                name,
+                public=public,
+                description=description
+            )
+            playlist_info = utils.parse_playlist(playlist, detailed=True)
+            return playlist_info if playlist_info else {}
+        except Exception as e:
+            self.logger.error(f"Error creating playlist: {str(e)}", exc_info=True)
+            raise
+
+    def get_playlist_cover_image(self, playlist_id: str) -> List[Dict[str, Any]]:
+        """Get a playlist's cover image"""
+        try:
+            images = self.sp.playlist_cover_image(playlist_id)
+            return images if images else []
+        except Exception as e:
+            self.logger.error(f"Error getting playlist cover: {str(e)}", exc_info=True)
+            raise
+
+    def upload_playlist_cover_image(self, playlist_id: str, image_data: str) -> None:
+        """Upload a custom playlist cover image"""
+        try:
+            self.sp.playlist_upload_cover_image(playlist_id, image_data)
+        except Exception as e:
+            self.logger.error(f"Error uploading playlist cover: {str(e)}", exc_info=True)
+            raise

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -15,13 +15,30 @@ CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
 CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
 REDIRECT_URI = os.getenv("SPOTIFY_REDIRECT_URI")
 
-SCOPES = ["user-read-currently-playing", "user-read-playback-state", "user-read-currently-playing",  # spotify connect
-          "app-remote-control", "streaming",  # playback
-          "playlist-read-private", "playlist-read-collaborative", "playlist-modify-private", "playlist-modify-public",
-          # playlists
-          "user-read-playback-position", "user-top-read", "user-read-recently-played",  # listening history
-          "user-library-modify", "user-library-read",  # library
-          ]
+# Define all required scopes
+SCOPES = [
+    # Playback
+    "user-read-currently-playing",
+    "user-read-playback-state",
+    "user-modify-playback-state",
+    "app-remote-control",
+    "streaming",
+
+    # Playlists
+    "playlist-read-private",
+    "playlist-read-collaborative",
+    "playlist-modify-private",
+    "playlist-modify-public",
+
+    # Library
+    "user-library-read",
+    "user-library-modify",
+
+    # History
+    "user-read-playback-position",
+    "user-top-read",
+    "user-read-recently-played",
+]
 
 class Client:
     sp: spotipy.Spotify

--- a/src/spotify_mcp/utils.py
+++ b/src/spotify_mcp/utils.py
@@ -1,14 +1,12 @@
 from collections import defaultdict
-from typing import Optional, Dict
 import functools
-from typing import Callable, TypeVar
-from typing import Optional, Dict
+from typing import Callable, TypeVar, Optional, Dict, List, Any
 from urllib.parse import quote
 
 T = TypeVar('T')
 
 
-def parse_track(track_item: dict, detailed=False) -> Optional[dict]:
+def parse_track(track_item: Optional[Dict[str, Any]], detailed: bool = False) -> Optional[Dict[str, Any]]:
     if not track_item:
         return None
     narrowed_item = {
@@ -39,7 +37,7 @@ def parse_track(track_item: dict, detailed=False) -> Optional[dict]:
     return narrowed_item
 
 
-def parse_artist(artist_item: dict, detailed=False) -> Optional[dict]:
+def parse_artist(artist_item: Optional[Dict[str, Any]], detailed: bool = False) -> Optional[Dict[str, Any]]:
     if not artist_item:
         return None
     narrowed_item = {
@@ -52,7 +50,7 @@ def parse_artist(artist_item: dict, detailed=False) -> Optional[dict]:
     return narrowed_item
 
 
-def parse_playlist(playlist_item: dict, detailed=False) -> Optional[dict]:
+def parse_playlist(playlist_item: Optional[Dict[str, Any]], detailed: bool = False) -> Optional[Dict[str, Any]]:
     if not playlist_item:
         return None
     narrowed_item = {
@@ -70,7 +68,9 @@ def parse_playlist(playlist_item: dict, detailed=False) -> Optional[dict]:
     return narrowed_item
 
 
-def parse_album(album_item: dict, detailed=False) -> dict:
+def parse_album(album_item: Optional[Dict[str, Any]], detailed: bool = False) -> Optional[Dict[str, Any]]:
+    if not album_item:
+        return None
     narrowed_item = {
         'name': album_item['name'],
         'id': album_item['id'],
@@ -96,7 +96,9 @@ def parse_album(album_item: dict, detailed=False) -> dict:
     return narrowed_item
 
 
-def parse_search_results(results: Dict, qtype: str):
+def parse_search_results(results: Optional[Dict[str, Any]], qtype: str) -> Dict[str, List[Dict[str, Any]]]:
+    if not results:
+        return {}
     _results = defaultdict(list)
 
     for q in qtype.split(","):


### PR DESCRIPTION
This PR adds support for most of Spotify's major playlist API functions, including 'set custom cover art' which might be fun to play with!

Manipulatin Spotify queue is great but I keep wanting Claude to save the queue into playlists,or even add songs to existing playlists that I have already. 

Still getting my feet wet with MCP (and python) so please forgive any errors or oversights

I have tried to fix a number of type safety things I ran into as well, and some additional logging. Happy to tone some of that down

Still testing this but working great so far!

![CleanShot 2025-01-18 at 16 33 13@2x](https://github.com/user-attachments/assets/34cf191c-4d86-44ce-a617-09d3217945c1)
