### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Use a Python image with uv pre-installed
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS uv
+
+# Install the project into /app
+WORKDIR /app
+
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
+# Install the project's dependencies using the lockfile and settings
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --no-dev --no-editable
+
+# Then, add the rest of the project source code and install it
+# Installing separately from its dependencies allows optimal layer caching
+ADD . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable
+
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app
+ 
+COPY --from=uv /root/.local /root/.local
+COPY --from=uv --chown=app:app /app/.venv /app/.venv
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Required environment variables
+ENV SPOTIFY_CLIENT_ID=your_client_id
+ENV SPOTIFY_CLIENT_SECRET=your_client_secret
+ENV SPOTIFY_REDIRECT_URI=http://localhost:8888
+
+# when running the container, add --db-path and a bind mount to the host's db file
+ENTRYPOINT ["uv", "--directory", "/app/src/spotify_mcp", "run", "spotify-mcp"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # spotify-mcp MCP server
 
+[![smithery badge](https://smithery.ai/badge/@varunneal/spotify)](https://smithery.ai/server/@varunneal/spotify)
+
 MCP project to connect Claude with Spotify. Built on top of [spotipy-dev's API](https://github.com/spotipy-dev/spotipy/tree/2.24.0).
 
 ## Features
@@ -28,6 +30,16 @@ Create an app with redirect_uri as http://localhost:8888. (You can choose any po
 I set "APIs used" to "Web Playback SDK".
 
 ### Run this project locally
+
+### Installing via Smithery
+
+To install Spotify Connector for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@varunneal/spotify):
+
+```bash
+npx -y @smithery/cli install @varunneal/spotify --client claude
+```
+
+### Manual Installation
 This project is not yet set up for ephemeral environments (e.g. `uvx` usage). 
 Run this project locally by cloning this repo
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,28 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+build:
+  dockerBuildPath: ./
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - spotifyClientId
+      - spotifyClientSecret
+      - spotifyRedirectUri
+    properties:
+      spotifyClientId:
+        type: string
+        description: The Spotify client ID for API authentication.
+      spotifyClientSecret:
+        type: string
+        description: The Spotify client secret for API authentication.
+      spotifyRedirectUri:
+        type: string
+        description: The redirect URI configured in your Spotify developer account.
+          Default is 'http://localhost:8888'.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({command: 'uv', args: ['--directory', '/app/src/spotify_mcp', 'run', 'spotify-mcp'], env: {SPOTIFY_CLIENT_ID: config.spotifyClientId, SPOTIFY_CLIENT_SECRET: config.spotifyClientSecret, SPOTIFY_REDIRECT_URI: config.spotifyRedirectUri}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. This file is used by [Smithery](https://smithery.ai?utm_campaign=pr) to render configurations for the end-user. It also allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to Smithery, serving it over SSE so end-users do not need to install additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/@varunneal/spotify?utm_campaign=pr&modal=claim), claiming it and clicking "Deploy".
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. Note that the installation only works after the server is deployed.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let us know if you have any questions. 🙂