### PR TITLE
Support playing albums and playlists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.cache
+__pycache__/

--- a/src/spotify_mcp/server.py
+++ b/src/spotify_mcp/server.py
@@ -64,12 +64,12 @@ class ToolModel(BaseModel):
 class Playback(ToolModel):
     """Manages the current playback with the following actions:
     - get: Get information about user's current track.
-    - start: Starts of resumes playback.
+    - start: Starts playing new item or resumes current playback if called with no uri.
     - pause: Pauses current playback.
     - skip: Skips current track.
     """
     action: str = Field(description="Action to perform: 'get', 'start', 'pause' or 'skip'.")
-    track_id: Optional[str] = Field(default=None, description="Specifies track to play for 'start' action. If omitted, resumes current playback.")
+    spotify_uri: Optional[str] = Field(default=None, description="Spotify uri of item to play for 'start' action. If omitted, resumes current playback.")
     num_skips: Optional[int] = Field(default=1, description="Number of tracks to skip for `skip` action.")
 
 
@@ -137,7 +137,7 @@ async def handle_call_tool(
                         )]
                     case "start":
                         logger.info(f"Starting playback with arguments: {arguments}")
-                        spotify_client.start_playback(track_id=arguments.get("track_id"))
+                        spotify_client.start_playback(spotify_uri=arguments.get("spotify_uri"))
                         logger.info("Playback started successfully")
                         return [types.TextContent(
                             type="text",

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -119,24 +119,36 @@ class Client:
             raise
 
     @utils.validate
-    def start_playback(self, track_id=None, device=None):
+    def start_playback(self, spotify_uri=None, device=None):
         """
-        Starts track playback. If track_id is omitted, resumes current playback.
-        - track_id: ID of track to play, or None.
+        Starts spotify playback of uri. If spotify_uri is omitted, resumes current playback.
+        - spotify_uri: ID of resource to play, or None. Typically looks like 'spotify:track:xxxxxx' or 'spotify:album:xxxxxx'.
         """
         try:
-            if not track_id:
+            self.logger.info(f"Starting playback for spotify_uri: {spotify_uri} on {device}")
+            if not spotify_uri:
                 if self.is_track_playing():
                     self.logger.info("No track_id provided and playback already active.")
                     return
                 if not self.get_current_track():
                     raise ValueError("No track_id provided and no current playback to resume.")
 
-            uris = [f'spotify:track:{track_id}'] if track_id else None
+            if spotify_uri is not None:
+                if spotify_uri.startswith('spotify:track:'):
+                    uris = [spotify_uri]
+                    context_uri = None
+                else:
+                    uris = None
+                    context_uri = spotify_uri
+            else:
+                uris = None
+                context_uri = None
+
             device_id = device.get('id') if device else None
 
-            result = self.sp.start_playback(uris=uris, device_id=device_id)
-            self.logger.info(f"Playback started successfully{' for track_id: ' + track_id if track_id else ''}")
+            self.logger.info(f"Starting playback of on {device}: context_uri={context_uri}, uris={uris}")
+            result = self.sp.start_playback(uris=uris, context_uri=context_uri, device_id=device_id)
+            self.logger.info(f"Playback result: {result}")
             return result
         except Exception as e:
             self.logger.error(f"Error starting playback: {str(e)}", exc_info=True)


### PR DESCRIPTION
Found I had to alternate handling of [`uris` vs `context_uri`](https://developer.spotify.com/documentation/web-api/reference/start-a-users-playback) in the `start` action to support playing albums or playlists in addition to supporting tracks.

Thanks for putting this mcp server together!