### PR TITLE
Update Spotify redirect URI from localhost to 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure to turn on audio
 
 ### Getting Spotify API Keys
 Create an account on [developer.spotify.com](https://developer.spotify.com/). Navigate to [the dashboard](https://developer.spotify.com/dashboard). 
-Create an app with redirect_uri as http://localhost:8888. (You can choose any port you want but you must use http and localhost). 
+Create an app with redirect_uri as http://127.0.0.1:8080/callback. (You can choose any port you want but you must use http and localhost). 
 I set "APIs used" to "Web Playback SDK".
 
 ### Run this project locally
@@ -54,7 +54,7 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
       "env": {
         "SPOTIFY_CLIENT_ID": YOUR_CLIENT_ID,
         "SPOTIFY_CLIENT_SECRET": YOUR_CLIENT_SECRET,
-        "SPOTIFY_REDIRECT_URI": "http://localhost:8888"
+        "SPOTIFY_REDIRECT_URI": "http://127.0.0.1:8080/callback"
       }
     }
   ```

--- a/src/spotify_mcp/server.py
+++ b/src/spotify_mcp/server.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field, AnyUrl
 from spotipy import SpotifyException
 
 from . import spotify_api
+from .utils import normalize_redirect_uri
 
 
 def setup_logger():
@@ -30,6 +31,9 @@ def setup_logger():
 
 
 logger = setup_logger()
+# Spotifyの要件に合わせてリダイレクトURIを正規化
+if spotify_api.REDIRECT_URI:
+    spotify_api.REDIRECT_URI = normalize_redirect_uri(spotify_api.REDIRECT_URI)
 spotify_client = spotify_api.Client(logger)
 
 

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -15,6 +15,10 @@ CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
 CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
 REDIRECT_URI = os.getenv("SPOTIFY_REDIRECT_URI")
 
+# Spotifyの要件に合わせてリダイレクトURIを正規化
+if REDIRECT_URI:
+    REDIRECT_URI = utils.normalize_redirect_uri(REDIRECT_URI)
+
 SCOPES = ["user-read-currently-playing", "user-read-playback-state", "user-read-currently-playing",  # spotify connect
           "app-remote-control", "streaming",  # playback
           "playlist-read-private", "playlist-read-collaborative", "playlist-modify-private", "playlist-modify-public",

--- a/src/spotify_mcp/utils.py
+++ b/src/spotify_mcp/utils.py
@@ -3,12 +3,27 @@ from typing import Optional, Dict
 import functools
 from typing import Callable, TypeVar
 from typing import Optional, Dict
-from urllib.parse import quote
+from urllib.parse import quote, urlparse, urlunparse
 
 from requests import RequestException
 
 T = TypeVar('T')
 
+
+def normalize_redirect_uri(url: str) -> str:
+    if not url:
+        return url
+        
+    parsed = urlparse(url)
+    
+    # Convert localhost to 127.0.0.1
+    if parsed.netloc == 'localhost' or parsed.netloc.startswith('localhost:'):
+        port = ''
+        if ':' in parsed.netloc:
+            port = ':' + parsed.netloc.split(':')[1]
+        parsed = parsed._replace(netloc=f'127.0.0.1{port}')
+    
+    return urlunparse(parsed)
 
 def parse_track(track_item: dict, detailed=False) -> Optional[dict]:
     if not track_item:


### PR DESCRIPTION
#18 

I have connected to spotify and confirmed that I can play it.

  ```json
  "spotify": {
      "command": "uv",
      "args": [
        "--directory",
        "/path/to/spotify_mcp",
        "run",
        "spotify-mcp"
      ],
      "env": {
        "SPOTIFY_CLIENT_ID": YOUR_CLIENT_ID,
        "SPOTIFY_CLIENT_SECRET": YOUR_CLIENT_SECRET,
        "SPOTIFY_REDIRECT_URI": "http://127.0.0.1:8080/callback"
      }
    }
  ```