### PR TITLE
List Favourite Songs Feature to the MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Make sure to turn on audio
 ### Getting Spotify API Keys
 
 Create an account on [developer.spotify.com](https://developer.spotify.com/). Navigate to [the dashboard](https://developer.spotify.com/dashboard).
-Create an app with redirect_uri as http://localhost:8888. (You can choose any port you want but you must use http and localhost).
+Create an app with redirect_uri as http://127.0.0.1:8888/callback. (You can choose any port you want but you must use http and 127.0.0.1).
 I set "APIs used" to "Web Playback SDK".
 
 ### Run this project locally
@@ -56,7 +56,7 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
       "env": {
         "SPOTIFY_CLIENT_ID": YOUR_CLIENT_ID,
         "SPOTIFY_CLIENT_SECRET": YOUR_CLIENT_SECRET,
-        "SPOTIFY_REDIRECT_URI": "http://localhost:8888"
+        "SPOTIFY_REDIRECT_URI": "http://127.0.0.1:8888/callback"
       }
     }
   ```

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -191,6 +191,24 @@ class Client:
 
         return queue_info
 
+    def get_favourite_songs(self, limit=20):
+        """
+        Fetches the user's favourite (liked) songs.
+        - limit: Maximum number of liked songs to fetch.
+        """
+        try:
+            results = self.sp.current_user_saved_tracks(limit=limit)
+            favourite_songs = []
+            for item in results['items']:
+                track = item['track']
+                favourite_songs.append(utils.parse_track(track))
+
+            self.logger.info(f"Fetched {len(favourite_songs)} favourite songs.")
+            return favourite_songs
+        except Exception as e:
+            self.logger.error(f"Error fetching favourite songs: {str(e)}")
+            raise
+
     def get_liked_songs(self):
         # todo
         results = self.sp.current_user_saved_tracks()


### PR DESCRIPTION
This PR introduces a new feature to list favorite songs using the Spotify Web API. The implementation adheres to Spotify's guidelines for redirect URIs as outlined in their documentation: [Spotify Redirect URI Documentation](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).

Key changes include:

Added functionality in the spotify_api.py module to fetch and list favorite songs.
Updated the [README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) file to include instructions on setting up the redirect URI and using the new feature.
<img width="420" alt="Screenshot 2025-04-19 at 5 28 10 PM" src="https://github.com/user-attachments/assets/2f67ce38-37d0-416f-968c-09f54775f6c5" />

These changes enhance the application's ability to interact with Spotify's API while ensuring compliance with their authentication requirements.