### PR TITLE
Fix: Correct directory path in README for local installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Add it to your MCP Config like this:
       "command": "uv",
       "args": [
         "--directory",
-        "/path/to/spotify_mcp",
+        "/path/to/spotify-mcp",
         "run",
         "spotify-mcp"
       ],
@@ -106,7 +106,7 @@ On other platforms [you can find logs here](https://modelcontextprotocol.io/quic
 You can launch the MCP Inspector via [`npm`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) with this command:
 
 ```bash
-npx @modelcontextprotocol/inspector uv --directory /path/to/spotify_mcp run spotify-mcp
+npx @modelcontextprotocol/inspector uv --directory /path/to/spotify-mcp run spotify-mcp
 ```
 
 Upon launching, the Inspector will display a URL that you can access in your browser to begin debugging.


### PR DESCRIPTION
Changed /path/to/spotify_mcp to /path/to/spotify-mcp in local installation instructions to match the actual repository name. This ensures users following the setup guide use the correct directory path when cloning and configuring the MCP server locally.

- Fixed path in MCP Config example (line 81)
- Fixed path in MCP Inspector command (line 109)