### PR TITLE
[codex] Fix Spotify playlist parsing and mutations

### DIFF
--- a/src/spotify_mcp/__init__.py
+++ b/src/spotify_mcp/__init__.py
@@ -1,10 +1,9 @@
-from . import server
 import asyncio
 
 def main():
     """Main entry point for the package."""
+    from . import server
+
     asyncio.run(server.main())
 
-# Optionally expose other important items at package level
-__all__ = ['main', 'server']
-
+__all__ = ['main']

--- a/src/spotify_mcp/server.py
+++ b/src/spotify_mcp/server.py
@@ -272,13 +272,16 @@ async def handle_call_tool(
                                     text="Error: track_ids must be a list or a valid JSON array."
                                 )]
 
-                        spotify_client.add_tracks_to_playlist(
+                        response = spotify_client.add_tracks_to_playlist(
                             playlist_id=arguments.get("playlist_id"),
                             track_ids=track_ids
                         )
                         return [types.TextContent(
                             type="text",
-                            text="Tracks added to playlist."
+                            text=json.dumps({
+                                "status": "Tracks added to playlist.",
+                                "spotify_response": response,
+                            }, indent=2)
                         )]
                     case "remove_tracks":
                         logger.info(f"Removing tracks from playlist with arguments: {arguments}")
@@ -293,13 +296,16 @@ async def handle_call_tool(
                                     text="Error: track_ids must be a list or a valid JSON array."
                                 )]
 
-                        spotify_client.remove_tracks_from_playlist(
+                        response = spotify_client.remove_tracks_from_playlist(
                             playlist_id=arguments.get("playlist_id"),
                             track_ids=track_ids
                         )
                         return [types.TextContent(
                             type="text",
-                            text="Tracks removed from playlist."
+                            text=json.dumps({
+                                "status": "Tracks removed from playlist.",
+                                "spotify_response": response,
+                            }, indent=2)
                         )]
 
                     case "change_details":

--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from typing import Optional, Dict, List
 
 import spotipy
@@ -50,7 +51,6 @@ class Client:
 
         self.username = None
 
-    @utils.validate
     def set_username(self, device=None):
         self.username = self.sp.current_user()['display_name']
 
@@ -89,15 +89,26 @@ class Client:
                 return album_info
             case 'artist':
                 artist_info = utils.parse_artist(self.sp.artist(item_id), detailed=True)
-                albums = self.sp.artist_albums(item_id)
+                try:
+                    albums = self.sp.artist_albums(
+                        item_id,
+                        album_type="album,single",
+                        limit=10,
+                        offset=0,
+                    )
+                except Exception as e:
+                    self.logger.error(f"Error getting artist albums: {str(e)}")
+                    albums = {'items': []}
+                    artist_info['albums_error'] = str(e)
+
                 top_tracks = self.sp.artist_top_tracks(item_id)['tracks']
                 albums_and_tracks = {
                     'albums': albums,
                     'tracks': {'items': top_tracks}
                 }
                 parsed_info = utils.parse_search_results(albums_and_tracks, qtype="album,track")
-                artist_info['top_tracks'] = parsed_info['tracks']
-                artist_info['albums'] = parsed_info['albums']
+                artist_info['top_tracks'] = parsed_info.get('tracks', [])
+                artist_info['albums'] = parsed_info.get('albums', [])
 
                 return artist_info
             case 'playlist':
@@ -216,24 +227,77 @@ class Client:
         Get current user's playlists.
         - limit: Max number of playlists to return.
         """
-        playlists = self.sp.current_user_playlists()
+        if self.username is None:
+            self.set_username()
+        playlists = self.sp.current_user_playlists(limit=limit)
         if not playlists:
             raise ValueError("No playlists found.")
         return [utils.parse_playlist(playlist, self.username) for playlist in playlists['items']]
     
-    @utils.ensure_username
     def get_playlist_tracks(self, playlist_id: str, limit=50) -> List[Dict]:
         """
         Get tracks from a playlist.
         - playlist_id: ID of the playlist to get tracks from.
         - limit: Max number of tracks to return.
         """
-        playlist = self.sp.playlist(playlist_id)
-        if not playlist:
-            raise ValueError("No playlist found.")
-        return utils.parse_tracks(playlist['tracks']['items'])
+        if not playlist_id:
+            raise ValueError("No playlist ID provided.")
+
+        playlist_items = self.sp.playlist_items(playlist_id, limit=limit)
+        items = playlist_items.get('items') or []
+        return utils.parse_tracks(items)
+
+    @staticmethod
+    def _normalize_track_uris(track_ids: List[str]) -> List[str]:
+        uris = []
+        for track_id in track_ids:
+            if track_id.startswith("spotify:track:") or track_id.startswith("http"):
+                uris.append(track_id)
+            else:
+                uris.append(f"spotify:track:{track_id}")
+        return uris
+
+    @staticmethod
+    def _track_id_from_uri(track_uri: str) -> str:
+        if track_uri.startswith("spotify:track:"):
+            return track_uri.split(":")[-1]
+        return track_uri.rstrip("/").split("/")[-1]
+
+    def _get_playlist_track_ids(self, playlist_id: str, limit=100) -> set[str]:
+        playlist_items = self.sp.playlist_items(playlist_id, limit=limit)
+        track_ids = set()
+        for item in playlist_items.get('items') or []:
+            track = None
+            if isinstance(item, dict):
+                track = item.get('item') or item.get('track')
+            if track and track.get('id'):
+                track_ids.add(track['id'])
+        return track_ids
+
+    def _wait_for_playlist_tracks(
+        self,
+        playlist_id: str,
+        track_ids: set[str],
+        should_exist: bool,
+        timeout_seconds: float = 10.0,
+    ) -> None:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            current_ids = self._get_playlist_track_ids(playlist_id)
+            is_consistent = (
+                track_ids.issubset(current_ids)
+                if should_exist
+                else track_ids.isdisjoint(current_ids)
+            )
+            if is_consistent:
+                return
+            if time.monotonic() >= deadline:
+                state = "appear in" if should_exist else "be removed from"
+                raise TimeoutError(
+                    f"Timed out waiting for tracks {sorted(track_ids)} to {state} playlist {playlist_id}."
+                )
+            time.sleep(1)
     
-    @utils.ensure_username
     def add_tracks_to_playlist(self, playlist_id: str, track_ids: List[str], position: Optional[int] = None):
         """
         Add tracks to a playlist.
@@ -246,13 +310,21 @@ class Client:
         if not track_ids:
             raise ValueError("No track IDs provided.")
         
+        track_uris = self._normalize_track_uris(track_ids)
+        normalized_track_ids = {self._track_id_from_uri(track_uri) for track_uri in track_uris}
         try:
-            response = self.sp.playlist_add_items(playlist_id, track_ids, position=position)
-            self.logger.info(f"Response from adding tracks: {track_ids} to playlist {playlist_id}: {response}")
+            response = self.sp.playlist_add_items(playlist_id, track_uris, position=position)
+            self.logger.info(f"Response from adding tracks: {track_uris} to playlist {playlist_id}: {response}")
+            self._wait_for_playlist_tracks(
+                playlist_id,
+                normalized_track_ids,
+                should_exist=True,
+            )
+            return response
         except Exception as e:
             self.logger.error(f"Error adding tracks to playlist: {str(e)}")
+            raise
 
-    @utils.ensure_username
     def remove_tracks_from_playlist(self, playlist_id: str, track_ids: List[str]):
         """
         Remove tracks from a playlist.
@@ -264,11 +336,20 @@ class Client:
         if not track_ids:
             raise ValueError("No track IDs provided.")
         
+        track_uris = self._normalize_track_uris(track_ids)
+        normalized_track_ids = {self._track_id_from_uri(track_uri) for track_uri in track_uris}
         try:
-            response = self.sp.playlist_remove_all_occurrences_of_items(playlist_id, track_ids)
-            self.logger.info(f"Response from removing tracks: {track_ids} from playlist {playlist_id}: {response}")
+            response = self.sp.playlist_remove_all_occurrences_of_items(playlist_id, track_uris)
+            self.logger.info(f"Response from removing tracks: {track_uris} from playlist {playlist_id}: {response}")
+            self._wait_for_playlist_tracks(
+                playlist_id,
+                normalized_track_ids,
+                should_exist=False,
+            )
+            return response
         except Exception as e:
             self.logger.error(f"Error removing tracks from playlist: {str(e)}")
+            raise
 
     @utils.ensure_username
     def create_playlist(self, name: str, description: Optional[str] = None, public: bool = True):
@@ -292,7 +373,7 @@ class Client:
                 description=description
             )
             self.logger.info(f"Created playlist: {name} (ID: {playlist['id']})")
-            return utils.parse_playlist(playlist, self.username, detailed=True)
+            return utils.parse_playlist(playlist, self.username, detailed=False)
         except Exception as e:
             self.logger.error(f"Error creating playlist: {str(e)}")
             raise

--- a/src/spotify_mcp/utils.py
+++ b/src/spotify_mcp/utils.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Optional, Dict
+from typing import Any, Optional, Dict
 import functools
 from typing import Callable, TypeVar
 from typing import Optional, Dict
@@ -72,18 +72,28 @@ def parse_artist(artist_item: dict, detailed=False) -> Optional[dict]:
 def parse_playlist(playlist_item: dict, username, detailed=False) -> Optional[dict]:
     if not playlist_item:
         return None
+    owner = playlist_item.get('owner') or {}
+    owner_name = owner.get('display_name') or owner.get('id')
+    tracks_info = playlist_item.get('items') or playlist_item.get('tracks') or {}
     narrowed_item = {
-        'name': playlist_item['name'],
-        'id': playlist_item['id'],
-        'owner': playlist_item['owner']['display_name'],
-        'user_is_owner': playlist_item['owner']['display_name'] == username,
-        'total_tracks': playlist_item['tracks']['total'],
+        'name': playlist_item.get('name'),
+        'id': playlist_item.get('id'),
+        'owner': owner_name,
+        'user_is_owner': owner_name == username,
+        'total_tracks': tracks_info.get('total', 0),
     }
     if detailed:
         narrowed_item['description'] = playlist_item.get('description')
         tracks = []
-        for t in playlist_item['tracks']['items']:
-            tracks.append(parse_track(t['track']))
+        for item in tracks_info.get('items') or []:
+            track_item = None
+            if isinstance(item, dict):
+                track_item = item.get('item') or item.get('track')
+            else:
+                track_item = item
+            track = parse_track(track_item)
+            if track:
+                tracks.append(track)
         narrowed_item['tracks'] = tracks
 
     return narrowed_item
@@ -144,7 +154,7 @@ def parse_search_results(results: Dict, qtype: str, username: Optional[str] = No
 
     return dict(_results)
 
-def parse_tracks(items: Dict) -> list:
+def parse_tracks(items: Dict[str, Any]) -> list:
     """
     Parse a list of track items and return a list of parsed tracks.
 
@@ -157,7 +167,13 @@ def parse_tracks(items: Dict) -> list:
     for idx, item in enumerate(items):
         if not item:
             continue
-        tracks.append(parse_track(item['track']))
+        if isinstance(item, dict):
+            track_item = item.get('item') or item.get('track')
+        else:
+            track_item = item
+        track = parse_track(track_item)
+        if track:
+            tracks.append(track)
     return tracks
 
 

--- a/tests/test_spotify_mcp_repairs.py
+++ b/tests/test_spotify_mcp_repairs.py
@@ -1,0 +1,154 @@
+import unittest
+from unittest.mock import Mock
+
+from spotify_mcp import utils
+from spotify_mcp.spotify_api import Client
+
+
+class TestPlaylistParsing(unittest.TestCase):
+    def test_parse_playlist_without_embedded_track_items(self):
+        playlist = {
+            "name": "Search Result",
+            "id": "playlist-id",
+            "owner": {"display_name": "palmer"},
+            "tracks": {
+                "total": 42,
+                "href": "https://api.spotify.com/v1/playlists/playlist-id/tracks",
+            },
+        }
+
+        parsed = utils.parse_playlist(playlist, "palmer", detailed=True)
+
+        self.assertEqual(parsed["id"], "playlist-id")
+        self.assertEqual(parsed["total_tracks"], 42)
+        self.assertEqual(parsed["tracks"], [])
+
+    def test_parse_playlist_without_tracks_key(self):
+        playlist = {
+            "name": "Created Playlist",
+            "id": "created-id",
+            "owner": {"id": "user-id"},
+        }
+
+        parsed = utils.parse_playlist(playlist, "user-id")
+
+        self.assertEqual(parsed["id"], "created-id")
+        self.assertEqual(parsed["owner"], "user-id")
+        self.assertEqual(parsed["total_tracks"], 0)
+
+    def test_parse_search_playlist_results(self):
+        results = {
+            "playlists": {
+                "items": [
+                    {
+                        "name": "Playlist",
+                        "id": "playlist-id",
+                        "owner": {"display_name": "palmer"},
+                        "tracks": {"total": 1},
+                    }
+                ]
+            }
+        }
+
+        parsed = utils.parse_search_results(results, "playlist", "palmer")
+
+        self.assertEqual(parsed["playlists"][0]["id"], "playlist-id")
+
+
+class TestArtistInfoFallback(unittest.TestCase):
+    def test_artist_info_returns_metadata_when_albums_fail(self):
+        client = Client.__new__(Client)
+        client.logger = Mock()
+        client.sp = Mock()
+        client.sp.artist.return_value = {
+            "name": "Daft Punk",
+            "id": "artist-id",
+            "genres": ["electronic"],
+        }
+        client.sp.artist_albums.side_effect = Exception("Invalid limit")
+        client.sp.artist_top_tracks.return_value = {
+            "tracks": [
+                {
+                    "name": "One More Time",
+                    "id": "track-id",
+                    "artists": [{"name": "Daft Punk", "id": "artist-id"}],
+                }
+            ]
+        }
+
+        parsed = client.get_info("spotify:artist:artist-id")
+
+        self.assertEqual(parsed["id"], "artist-id")
+        self.assertEqual(parsed["top_tracks"][0]["id"], "track-id")
+        self.assertEqual(parsed["albums"], [])
+        self.assertIn("albums_error", parsed)
+
+
+class TestPlaylistMutation(unittest.TestCase):
+    def test_get_playlist_tracks_reads_playlist_items_endpoint(self):
+        client = Client.__new__(Client)
+        client.sp = Mock()
+        client.sp.playlist_items.return_value = {
+            "items": [
+                {
+                    "item": {
+                        "name": "One More Time",
+                        "id": "track-id",
+                        "artists": [{"name": "Daft Punk"}],
+                    }
+                }
+            ]
+        }
+
+        tracks = client.get_playlist_tracks("playlist-id")
+
+        client.sp.playlist_items.assert_called_once_with("playlist-id", limit=50)
+        self.assertEqual(tracks[0]["id"], "track-id")
+
+    def test_add_tracks_normalizes_ids_and_returns_response(self):
+        client = Client.__new__(Client)
+        client.logger = Mock()
+        client.sp = Mock()
+        client.sp.playlist_add_items.return_value = {"snapshot_id": "snapshot"}
+        client.sp.playlist_items.return_value = {
+            "items": [{"item": {"id": "track-id"}}]
+        }
+
+        response = client.add_tracks_to_playlist("playlist-id", ["track-id"])
+
+        client.sp.playlist_add_items.assert_called_once_with(
+            "playlist-id",
+            ["spotify:track:track-id"],
+            position=None,
+        )
+        self.assertEqual(response["snapshot_id"], "snapshot")
+
+    def test_add_tracks_raises_spotify_errors(self):
+        client = Client.__new__(Client)
+        client.logger = Mock()
+        client.sp = Mock()
+        client.sp.playlist_add_items.side_effect = RuntimeError("forbidden")
+
+        with self.assertRaises(RuntimeError):
+            client.add_tracks_to_playlist("playlist-id", ["track-id"])
+
+    def test_remove_tracks_normalizes_ids_and_returns_response(self):
+        client = Client.__new__(Client)
+        client.logger = Mock()
+        client.sp = Mock()
+        client.sp.playlist_remove_all_occurrences_of_items.return_value = {
+            "snapshot_id": "snapshot"
+        }
+        client.sp.playlist_items.return_value = {"items": []}
+
+        response = client.remove_tracks_from_playlist("playlist-id", ["track-id"])
+
+        client.sp.playlist_remove_all_occurrences_of_items.assert_called_once_with(
+            "playlist-id",
+            ["spotify:track:track-id"],
+        )
+        self.assertEqual(response["snapshot_id"], "snapshot")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make playlist parsing tolerate Spotify responses without embedded track items
- support Spotify 2026 playlist item payloads that use `item` instead of `track`
- make playlist add/remove operations return Spotify responses and raise failures instead of reporting success after swallowed exceptions
- add focused unit tests for playlist parsing, playlist mutations, and artist album fallback

## Why

Spotify playlist responses are not consistent across search, create, list, and item endpoints. Some payloads only include track totals, some omit embedded track arrays, and newer playlist item responses expose the playable object under `item` rather than `track`. The old parser assumed `tracks.items[].track`, which caused playlist search/list/create/read flows to fail or silently return empty results.

Playlist mutation methods also logged exceptions without re-raising, so the MCP server could return `Tracks added to playlist.` even when the underlying Spotify API operation failed.

## Validation

```text
uv run python -m unittest discover -s tests
........
----------------------------------------------------------------------
Ran 8 tests in 0.001s

OK
```

I also validated the patched behavior against a real Spotify test playlist locally: add made the target track visible via `get_playlist_tracks`, and remove returned the playlist to its original empty state.
