### PR TITLE
fix: handle Spotify API rename of 'track'/'tracks' keys to 'item'/'items'

### DIFF
--- a/src/spotify_mcp/spotify_api.py
+++ b/src/spotify_mcp/spotify_api.py
@@ -211,6 +211,7 @@ class Client:
             return True
         return False
 
+    @utils.ensure_username
     def get_current_user_playlists(self, limit=50) -> List[Dict]:
         """
         Get current user's playlists.
@@ -219,7 +220,12 @@ class Client:
         playlists = self.sp.current_user_playlists()
         if not playlists:
             raise ValueError("No playlists found.")
-        return [utils.parse_playlist(playlist, self.username) for playlist in playlists['items']]
+        result = []
+        for playlist in playlists['items']:
+            parsed = utils.parse_playlist(playlist, self.username)
+            if parsed:
+                result.append(parsed)
+        return result
     
     @utils.ensure_username
     def get_playlist_tracks(self, playlist_id: str, limit=50) -> List[Dict]:
@@ -231,7 +237,8 @@ class Client:
         playlist = self.sp.playlist(playlist_id)
         if not playlist:
             raise ValueError("No playlist found.")
-        return utils.parse_tracks(playlist['tracks']['items'])
+        items_info = playlist.get('items') or playlist.get('tracks') or {}
+        return utils.parse_tracks(items_info.get('items', []))
     
     @utils.ensure_username
     def add_tracks_to_playlist(self, playlist_id: str, track_ids: List[str], position: Optional[int] = None):

--- a/src/spotify_mcp/utils.py
+++ b/src/spotify_mcp/utils.py
@@ -72,18 +72,23 @@ def parse_artist(artist_item: dict, detailed=False) -> Optional[dict]:
 def parse_playlist(playlist_item: dict, username, detailed=False) -> Optional[dict]:
     if not playlist_item:
         return None
+    items_info = playlist_item.get('items') or playlist_item.get('tracks') or {}
+    owner = playlist_item.get('owner') or {}
     narrowed_item = {
         'name': playlist_item['name'],
         'id': playlist_item['id'],
-        'owner': playlist_item['owner']['display_name'],
-        'user_is_owner': playlist_item['owner']['display_name'] == username,
-        'total_tracks': playlist_item['tracks']['total'],
+        'owner': owner.get('display_name', ''),
+        'user_is_owner': owner.get('display_name') == username,
+        'total_tracks': items_info.get('total', 0),
     }
     if detailed:
         narrowed_item['description'] = playlist_item.get('description')
         tracks = []
-        for t in playlist_item['tracks']['items']:
-            tracks.append(parse_track(t['track']))
+        for t in items_info.get('items', []):
+            raw_track = (t.get('item') or t.get('track')) if t else None
+            parsed = parse_track(raw_track) if raw_track else None
+            if parsed:
+                tracks.append(parsed)
         narrowed_item['tracks'] = tracks
 
     return narrowed_item
@@ -157,7 +162,12 @@ def parse_tracks(items: Dict) -> list:
     for idx, item in enumerate(items):
         if not item:
             continue
-        tracks.append(parse_track(item['track']))
+        raw_track = item.get('item') or item.get('track')
+        if not raw_track:
+            continue
+        parsed = parse_track(raw_track)
+        if parsed:
+            tracks.append(parsed)
     return tracks
 
 


### PR DESCRIPTION
## Problem

Spotify's Web API silently renamed keys in playlist response objects:

| Old key | New key | Location |
|---------|---------|----------|
| `tracks` | `items` | Playlist envelope (the dict wrapping track list + total) |
| `track` | `item` | Individual track entry within that list |

This caused `KeyError` crashes on any call that reads playlist contents — `get_playlist_tracks`, `parse_playlist`, and `parse_tracks` all hard-coded the old key names.

## Fix

Use a `.get()` fallback that accepts both key names so the code works regardless of which version the API returns:

```python
# Before
playlist['tracks']['items']

# After
items_info = playlist.get('items') or playlist.get('tracks') or {}
items_info.get('items', [])
```

Same pattern applied consistently in:
- `utils.parse_tracks` — `item['track']` → `item.get('item') or item.get('track')`
- `utils.parse_playlist` — track envelope + individual track + owner field access made safe
- `spotify_api.get_playlist_tracks` — top-level playlist dict access

Also adds the missing `@utils.ensure_username` decorator to `get_current_user_playlists` and filters `None` results from `parse_playlist` to avoid downstream errors on partial API responses.

## Testing

Verified against a live Spotify account with 20+ playlists and 100–130 track playlists. All playlist listing, track fetching, add, and remove operations work correctly after this change.